### PR TITLE
feat/pip snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ will simply update the comfy.yaml file to reflect the local setup
 * You can use the `comfy which` command to check the path of the target workspace.
   * e.g `comfy --recent which`, `comfy --here which`, `comfy which`, ...
 
+
 ### Launch ComfyUI
 
 Comfy provides commands that allow you to easily run the installed ComfyUI.
@@ -85,7 +86,7 @@ comfy provides a convenient way to manage custom nodes for extending ComfyUI's f
 
 - Show custom nodes' information:
  ```
-comfy node [show|simple-show] [installed|enabled|not-installed|disabled|all|snapshot|snapshot-list] 
+comfy node [show|simple-show] [installed|enabled|not-installed|disabled|all|snapshot|snapshot-list]
                               ?[--channel <channel name>] 
                               ?[--mode [remote|local|cache]]
 ```
@@ -104,6 +105,18 @@ comfy node [show|simple-show] [installed|enabled|not-installed|disabled|all|snap
   `comfy node save-snapshot`
 
   `comfy node restore-snapshot <snapshot name>`
+
+
+- Install dependencies:
+
+  `comfy node install-deps --deps=<deps .json file>` 
+
+  `comfy node install-deps --workflow=<workflow .json/.png file>`
+
+
+- Generate deps:
+
+  `comfy node deps-in-workflow --workflow=<workflow .json/.png file>` 
 
 
 ### Managing Models

--- a/comfy_cli/command/custom_nodes/command.py
+++ b/comfy_cli/command/custom_nodes/command.py
@@ -1,8 +1,8 @@
 import typer
 from typing_extensions import List, Annotated
+from typing import Optional
 
 from comfy_cli import tracking
-from comfy_cli.env_checker import EnvChecker
 import os
 import subprocess
 import sys
@@ -85,7 +85,7 @@ def validate_comfyui_manager(_env_checker):
 def save_snapshot(
     output: Annotated[
         str,
-        "--output",
+        None,
         typer.Option(
             show_default=False, help="Specify the output file path. (.json/.yaml)"
         ),
@@ -100,9 +100,40 @@ def save_snapshot(
 
 @app.command("restore-snapshot")
 @tracking.track_command("node")
-def restore_snapshot(path: str):
+def restore_snapshot(
+    path: str,
+    pip_non_url: Optional[bool] = typer.Option(
+        default=None,
+        show_default=False,
+        is_flag=True,
+        help="Restore for pip packages registered on PyPI.",
+    ),
+    pip_non_local_url: Optional[bool] = typer.Option(
+        default=None,
+        show_default=False,
+        is_flag=True,
+        help="Restore for pip packages registered at web URLs.",
+    ),
+    pip_local_url: Optional[bool] = typer.Option(
+        default=None,
+        show_default=False,
+        is_flag=True,
+        help="Restore for pip packages specified by local paths.",
+    ),
+):
+    extras = []
+
+    if pip_non_url:
+        extras += ["--pip-non-url"]
+
+    if pip_non_local_url:
+        extras += ["--pip-non-local-url"]
+
+    if pip_local_url:
+        extras += ["--pip-local-url"]
+
     path = os.path.abspath(path)
-    execute_cm_cli(["restore-snapshot", path])
+    execute_cm_cli(["restore-snapshot", path] + extras)
 
 
 @app.command("restore-dependencies")
@@ -217,11 +248,10 @@ def install(
     args: List[str] = typer.Argument(..., help="install custom nodes"),
     channel: Annotated[
         str,
-        "--channel",
         typer.Option(show_default=False, help="Specify the operation mode"),
     ] = None,
     mode: Annotated[
-        str, "--mode", typer.Option(show_default=False, help="[remote|local|cache]")
+        str, typer.Option(show_default=False, help="[remote|local|cache]")
     ] = None,
 ):
     if "all" in args:
@@ -400,18 +430,17 @@ def fix(
 @tracking.track_command("node")
 def install_deps(
     deps: Annotated[
-        str, None, typer.Option(show_default=False, help="Dependency spec file (.json)")
+        str, typer.Option(show_default=False, help="Dependency spec file (.json)")
     ] = None,
     workflow: Annotated[
-        str, None, typer.Option(show_default=False, help="Workflow file (.json/.png)")
+        str, typer.Option(show_default=False, help="Workflow file (.json/.png)")
     ] = None,
     channel: Annotated[
         str,
-        "--channel",
         typer.Option(show_default=False, help="Specify the operation mode"),
     ] = None,
     mode: Annotated[
-        str, "--mode", typer.Option(show_default=False, help="[remote|local|cache]")
+        str, typer.Option(show_default=False, help="[remote|local|cache]")
     ] = None,
 ):
     valid_modes = ["remote", "local", "cache"]
@@ -457,10 +486,10 @@ def install_deps(
 @tracking.track_command("node")
 def deps_in_workflow(
     workflow: Annotated[
-        str, None, typer.Option(show_default=False, help="Workflow file (.json/.png)")
+        str, typer.Option(show_default=False, help="Workflow file (.json/.png)")
     ],
     output: Annotated[
-        str, None, typer.Option(show_default=False, help="Workflow file (.json/.png)")
+        str, typer.Option(show_default=False, help="Workflow file (.json/.png)")
     ],
     channel: Annotated[
         str,
@@ -468,7 +497,7 @@ def deps_in_workflow(
         typer.Option(show_default=False, help="Specify the operation mode"),
     ] = None,
     mode: Annotated[
-        str, "--mode", typer.Option(show_default=False, help="[remote|local|cache]")
+        str, typer.Option(show_default=False, help="[remote|local|cache]")
     ] = None,
 ):
     valid_modes = ["remote", "local", "cache"]

--- a/comfy_cli/command/custom_nodes/command.py
+++ b/comfy_cli/command/custom_nodes/command.py
@@ -396,6 +396,31 @@ def fix(
     execute_cm_cli(["fix"] + args, channel, mode)
 
 
+@app.command("install-deps")
+@tracking.track_command("node")
+def install_deps(
+    deps_file: str,
+    channel: Annotated[
+        str,
+        "--channel",
+        typer.Option(show_default=False, help="Specify the operation mode"),
+    ] = None,
+    mode: Annotated[
+        str, "--mode", typer.Option(show_default=False, help="[remote|local|cache]")
+    ] = None,
+):
+    valid_modes = ["remote", "local", "cache"]
+    if mode and mode.lower() not in valid_modes:
+        typer.echo(
+            f"Invalid mode: {mode}. Allowed modes are 'remote', 'local', 'cache'.",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
+    deps_file = os.path.abspath(os.path.expanduser(deps_file))
+    execute_cm_cli(["install-deps", deps_file], channel, mode)
+
+
 # TODO: re-enable publish after v0 launch
 # @app.command("publish", help="Publish node to registry")
 # @tracking.track_command("publish")


### PR DESCRIPTION
support pip snapshots in snapshot command

ComfyUI-Manager 2.27+ is required

e.g)
```
comfy node restore-snapshot /mnt/teratera/git/ComfyUI/custom_nodes/ComfyUI-Manager/here.json --pip-non-local-url
```

added options:
`--pip-non-url`:  Restore for pip packages registered on PyPI.
`--pip-non-local-url`: Restore for pip packages registered at web URLs.
`--pip-local-url`: Restore for pip packages specified by local paths.
