### PR TITLE
fix: civitai downloading

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,13 +147,13 @@ comfy node [show|simple-show] [installed|enabled|not-installed|disabled|all|snap
 
 - Model downloading
 
-  `comfy model get`
+  `comfy model download ?[--relative-path <PATH>] --url <URL> `
 
-  \*Downloading models that have already been installed will
+  * URL: CivitAI, huggingface file url, ...
 
 - Model remove
 
-  `comfy model enable-gui`
+  `comfy model remove ?[--relative-path <PATH>] --model-names <model names>`
 
 - Model list
 

--- a/comfy_cli/command/models/models.py
+++ b/comfy_cli/command/models/models.py
@@ -80,7 +80,7 @@ def request_civitai_model_version_api(version_id: int, headers: Optional[dict] =
 
     model_data = response.json()
     for file in model_data["files"]:
-        if file["primary"]:  # Assuming we want the primary file
+        if file.get("primary", False):  # Assuming we want the primary file
             model_name = file["name"]
             download_url = file["downloadUrl"]
             return model_name, download_url
@@ -106,7 +106,7 @@ def request_civitai_model_api(
         if version["id"] == version_id:
             # Get the model name and download URL from the files array
             for file in version["files"]:
-                if file["primary"]:  # Assuming we want the primary file
+                if file.get("primary", False):  # Assuming we want the primary file
                     model_name = file["name"]
                     download_url = file["downloadUrl"]
                     return model_name, download_url
@@ -269,7 +269,6 @@ def list(
         show_default=True,
     ),
 ):
-
     """Display a list of all models currently downloaded in a table format."""
     model_dir = get_workspace() / relative_path
     models = list_models(model_dir)

--- a/comfy_cli/command/models/models.py
+++ b/comfy_cli/command/models/models.py
@@ -130,7 +130,7 @@ def request_civitai_model_api(
     raise ValueError(f"Version ID {version_id} not found for model ID {model_id}")
 
 
-@app.command(help='Download model file from url')
+@app.command(help="Download model file from url")
 @tracking.track_command("model")
 def download(
     _ctx: typer.Context,
@@ -191,10 +191,12 @@ def download(
         if relative_path is None:
             if model_path is None:
                 model_path = ui.prompt_input(
-                    "Enter model type path (e.g. loras, checkpoints, ...)", default=''
+                    "Enter model type path (e.g. loras, checkpoints, ...)", default=""
                 )
 
-            relative_path = os.path.join(DEFAULT_COMFY_MODEL_PATH, model_path, basemodel)
+            relative_path = os.path.join(
+                DEFAULT_COMFY_MODEL_PATH, model_path, basemodel
+            )
     elif is_civitai_api_url:
         local_filename, url, model_type, basemodel = request_civitai_model_version_api(
             version_id, headers
@@ -205,22 +207,26 @@ def download(
         if relative_path is None:
             if model_path is None:
                 model_path = ui.prompt_input(
-                    "Enter model type path (e.g. loras, checkpoints, ...)", default=''
+                    "Enter model type path (e.g. loras, checkpoints, ...)", default=""
                 )
 
-            relative_path = os.path.join(DEFAULT_COMFY_MODEL_PATH, model_path, basemodel)
+            relative_path = os.path.join(
+                DEFAULT_COMFY_MODEL_PATH, model_path, basemodel
+            )
     elif check_huggingface_url(url):
         is_huggingface = True
         local_filename = potentially_strip_param_url(url.split("/")[-1])
 
         if relative_path is None:
             model_path = ui.prompt_input(
-                "Enter model type path (e.g. loras, checkpoints, ...)", default=''
+                "Enter model type path (e.g. loras, checkpoints, ...)", default=""
             )
             basemodel = ui.prompt_input(
-                "Enter base model (e.g. SD1.5, SDXL, ...)", default=''
+                "Enter base model (e.g. SD1.5, SDXL, ...)", default=""
             )
-            relative_path = os.path.join(DEFAULT_COMFY_MODEL_PATH, model_path, basemodel)
+            relative_path = os.path.join(
+                DEFAULT_COMFY_MODEL_PATH, model_path, basemodel
+            )
     else:
         print("Model source is unknown")
 

--- a/comfy_cli/command/models/models.py
+++ b/comfy_cli/command/models/models.py
@@ -1,5 +1,6 @@
 import pathlib
 from typing import List, Optional, Tuple
+from rich import print
 
 import requests
 import typer

--- a/comfy_cli/command/models/models.py
+++ b/comfy_cli/command/models/models.py
@@ -291,8 +291,6 @@ def remove(
             if not to_delete:
                 return  # Exit if no valid models were found
 
-        return
-
     # Scenario #2: User did not provide model names, prompt for selection
     else:
         selections = ui.prompt_multi_select(

--- a/comfy_cli/constants.py
+++ b/comfy_cli/constants.py
@@ -11,7 +11,7 @@ class OS(Enum):
 COMFY_GITHUB_URL = "https://github.com/comfyanonymous/ComfyUI"
 COMFY_MANAGER_GITHUB_URL = "https://github.com/ltdrdata/ComfyUI-Manager"
 
-DEFAULT_COMFY_MODEL_PATH = "models/checkpoints"
+DEFAULT_COMFY_MODEL_PATH = "models"
 DEFAULT_COMFY_WORKSPACE = {
     OS.WINDOWS: os.path.join(os.path.expanduser("~"), "Documents", "comfy", "ComfyUI"),
     OS.MACOS: os.path.join(os.path.expanduser("~"), "Documents", "comfy", "ComfyUI"),


### PR DESCRIPTION
fix: Download the model to the appropriate location based on its type.
fix: civitai download fail  when model page contains training data
fix: model remove command
improve: prompt support for unknown path specifying